### PR TITLE
Fix infinite recursion on -tagname

### DIFF
--- a/e621dl/remote.py
+++ b/e621dl/remote.py
@@ -88,11 +88,11 @@ def get_tag_alias(user_tag, session):
 
     if user_tag[0] == '~':
         prefix = '~'
-        user_tag = user_tag[1:]
+        return prefix+get_tag_alias(user_tag, session)
 
     if user_tag[0] == '-':
         prefix = '-'
-        user_tag = user_tag[1:]
+        return prefix+get_tag_alias(user_tag, session)
 
     url = 'https://e621.net/tag/index.json'
     payload = {'name': user_tag}

--- a/e621dl/remote.py
+++ b/e621dl/remote.py
@@ -88,11 +88,11 @@ def get_tag_alias(user_tag, session):
 
     if user_tag[0] == '~':
         prefix = '~'
-        return prefix+get_tag_alias(user_tag, session)
+        return prefix+get_tag_alias(user_tag[1:], session)
 
     if user_tag[0] == '-':
         prefix = '-'
-        return prefix+get_tag_alias(user_tag, session)
+        return prefix+get_tag_alias(user_tag[1:], session)
 
     url = 'https://e621.net/tag/index.json'
     payload = {'name': user_tag}

--- a/e621dl/remote.py
+++ b/e621dl/remote.py
@@ -2,6 +2,7 @@
 import os
 from time import sleep
 from timeit import default_timer
+from functools import lru_cache
 
 # Personal Imports
 from e621dl import constants
@@ -75,6 +76,7 @@ def get_known_post(post_id, session):
 
     return response.json()
 
+@lru_cache(maxsize=512, typed=False)
 def get_tag_alias(user_tag, session):
     prefix = ''
 


### PR DESCRIPTION
`RecursionError: maximum recursion depth exceeded in comparison` when trying to use `-tagname` in a search.

(At least, I assume this is what the code intended to do, and it works now)